### PR TITLE
Fix quicksearch hard coding

### DIFF
--- a/Sources/EPiServer.Reference.Commerce.Site/Views/Search/QuickSearch.cshtml
+++ b/Sources/EPiServer.Reference.Commerce.Site/Views/Search/QuickSearch.cshtml
@@ -1,4 +1,4 @@
-﻿@model IEnumerable<EPiServer.Reference.Commerce.Site.Features.Product.ViewModels.ProductViewModel>
+@model IEnumerable<EPiServer.Reference.Commerce.Site.Features.Product.ViewModels.ProductViewModel>
 @{
     Layout = null;
 }
@@ -23,8 +23,8 @@
                             <h4 class="product-row__item__price product-price--discount">@Helpers.RenderMoney(product.DiscountedPrice.GetValueOrDefault())</h4>
                         }
                         <h4 class="product-row__item__price product-price">@Helpers.RenderMoney(product.PlacedPrice)</h4>
-                        <span class="product-row__item__brand product-brand text-muted">Lyle &amp; Scott</span>
-                        <p class="product-row__item__description">Jacket from Lyle &amp; Scott. Rounded neckline with collar and button closure. Zipper closure and two pockets at front. Elastic at each cuff and hem. Lined. Made of 100% Cotton.</p>
+                        <span class="product-row__item__brand product-brand text-muted">@product.Brand</span>
+                        <p class="product-row__item__description">@* TODO: Add the product description to the product view model *@</p>
                     </div>
                 </div>
             </a>


### PR DESCRIPTION
The quick search results have hard coded brand and descriptions in. Replace result with a proper brand and added a todo to populate the description (need change to ProductViewModel so can be committed in separate request).